### PR TITLE
Removed ui.make_query(args) and replaced with args

### DIFF
--- a/beetsplug/cmus.py
+++ b/beetsplug/cmus.py
@@ -58,7 +58,7 @@ def cmus_remote(lib, config, opts, args):
         subprocess.call(cmd + ['--clear'] + cmd_args)
     
     if opts.add:
-        for item in lib.items( ui.make_query(args)):
+        for item in lib.items( args ):
             subprocess.call(cmd + cmd_args + [item.path])
 
     if opts.stop:


### PR DESCRIPTION
 matches a change in beets 1.0b9 "use separate shell arguments for queries to preserve whitespace" (Jun 26 2011)
